### PR TITLE
Enable regex filter on folder as well as files

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,6 +353,7 @@
 
           this.pathContentTableData = [];
           commonPrefixes
+            .filter(prefix => !config.keyExcludePatterns.find(pattern => pattern.test(prefix.prefix)))
             .forEach(prefix => {
               this.pathContentTableData.push({
                 type: 'prefix',


### PR DESCRIPTION
Seems to work in my quick testing. Enables for Folders to be filtered out as well as Files using the keyExcludePatterns key.