### PR TITLE
bug fixes for folders containing Spaces.

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
         pathBreadcrumps() {
           return `/${this.pathPrefix}`.match(/(?=[/])|[^/]+[/]?/g)
             .map((pathPrefixPart, index, pathPrefixParts) => ({
-              name: pathPrefixPart,
+              name: decodeURI(pathPrefixPart),
               url: '#' + pathPrefixParts.slice(0, index).join('') + pathPrefixPart
             }));
         },
@@ -365,7 +365,7 @@
             .filter(content => !config.keyExcludePatterns.find(pattern => pattern.test(content.key)))
             .forEach(content => {
               if(content.key.endsWith('/') && !content.size){
-                if(content.key !== this.pathPrefix)
+                if(content.key !== decodeURI(this.pathPrefix))
                 this.pathContentTableData.push({
                   type: 'prefix',
                   name: content.key.split('/')[0] + '/',


### PR DESCRIPTION
1. If folder contained a "space" it appears in breadcrumbs as %20 (line: 283) - added decodeURI
2. If folder contains a space in name it appears in sub folders. (line 375) - added decodeURI