### PR TITLE
fix: Add custom path encoder

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,11 @@
       return /iPad|iPhone|iPod/.test(navigator.platform) ||
         (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
     }
+
+    function encodePath(path) {
+      const replaceChars = { ";": "%3B", "?": "%3F", ":": "%3A", "@": "%40", "&": "%26", "=": "%3D", "+": "%2B", "$": "%24", ",": "%2C", "#": "%23" }
+      return encodeURI(path).split("").map(char => replaceChars[char] || char).join("");
+    }
   </script>
 
 
@@ -443,7 +448,7 @@
       methods: {
         moment,
         urlFromPathPrefix(pathPrefix) {
-          return `${(this.config.bucketMaskUrl || this.config.bucketUrl).replace(/\/*$/,'')}/${encodeURIComponent(pathPrefix)}`
+          return `${(this.config.bucketMaskUrl || this.config.bucketUrl).replace(/\/*$/,'')}/${encodePath(pathPrefix)}`
         },
         validBucketPrefix(prefix) {
           if(prefix === '') return true
@@ -486,7 +491,7 @@
               bucketListApiUrl += `&max-keys=${config.pageSize}`
             }
             if (this.continuationToken) {
-              bucketListApiUrl += `&continuation-token=${encodeURIComponent(this.continuationToken)}`
+              bucketListApiUrl += `&continuation-token=${encodePath(this.continuationToken)}`
             }
             let listBucketResultResponse = await fetch(bucketListApiUrl)
             let listBucketResultXml = await listBucketResultResponse.text()
@@ -536,11 +541,11 @@
                 }
               }
 
-              let url = `${(config.bucketMaskUrl || config.bucketUrl).replace(/\/*$/,'')}/${encodeURIComponent(content.key)}`
+              let url = `${(config.bucketMaskUrl || config.bucketUrl).replace(/\/*$/,'')}/${encodePath(content.key)}`
               let installUrl = undefined
               if (url.endsWith('/manifest.plist') && devicePlatform_iOS()) {
                 // generate manifest.plist install urls
-                installUrl = `itms-services://?action=download-manifest&url=${encodeURIComponent(url)}`
+                installUrl = `itms-services://?action=download-manifest&url=${encodePath(url)}`
               }
               return {
                 type: 'content',


### PR DESCRIPTION
As of issue #38 `/` delimeters was encoded to `%2F`. This was fixed by changing `encodeURIComponent` to `encodeURI`. However, this raised an issue of `+` signs not working in directory names and this was fixed in PR #41 by changing these functions back to the original.

The difference between `encodeURI` and `encodeURIComponent` is that `;/?:@&=+$,#` are not escaped in `encodeURI` ([ECMA Docs](https://tc39.es/ecma262/multipage/global-object.html#sec-encodeuri-uri)).

On this project `encodeURI` is not good, as it does not escape characters that could be in file/dir names and S3 does not understand them when they're not escaped.

On the other hand `encodeURIComponent` is encoding `/` as well, which works but does not look good when copying the URL of a file.

This PR fixes the issues in these functions by creating a new function `encodePath`, giving the best of two functions utilizing `encodeURI` and encoding the missing characters that `encodeURIComponent` escapes compared to `encodeURI`.

