### PR TITLE
Update verification on the listBucket result

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,8 +497,9 @@
             let listBucketResultXml = await listBucketResultResponse.text()
 
             listBucketResult = new DOMParser().parseFromString(listBucketResultXml, "text/xml")
-            if (!listBucketResult.querySelector('ListBucketResult > Delimiter')) {
-              throw Error(`Bucket URL ${config.bucketUrl} is not a valid bucket API URL, response does not contain <ListBucketResult><Delimiter> tag.`)
+
+            if (!listBucketResult.querySelector('ListBucketResult')) {
+              throw Error(`Bucket URL ${config.bucketUrl} is not a valid bucket API URL, response does not contain <ListBucketResult> tag.`)
             }
           } catch (error) {
             this.$buefy.notification.open({


### PR DESCRIPTION
Remove the verification on the `Delimiter` tag
Because the `Delimiter` tag is not mandatory in the `ListBucketResult` object:  https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_ResponseElements