### PR TITLE
Fix Markdown preview when searching

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
                   v-if="props.row.type === 'content' && props.row.name.endsWith('.md')"
                   type="is-text"
                   tag="a"
-                  :href="`#${pathPrefix + props.row.name}::markdown`"
+                  :href="`#${pathPrefix.replace(/[^/]*$/, '') + props.row.name}::markdown`"
                   icon-left="image" size="is-medium"
                   target="_blank"
                 ></b-button>

--- a/index.html
+++ b/index.html
@@ -44,16 +44,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link id="favicon" rel="shortcut icon" />
 
-  <script src="https://unpkg.com/vue@2.6.14/dist/vue.min.js" integrity="sha384-ULpZhk1pvhc/UK5ktA9kwb2guy9ovNSTyxPNHANnA35YjBQgdwI+AhLkixDvdlw4" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/vue@2.7.16/dist/vue.min.js" integrity="sha384-YVYXhPGIH/Gmcr0W5Rin4PcpcsG1a4pcdUUod1CnbDEJut7XiUaJtSlNKeRLJBPk" crossorigin="anonymous"></script>
   <script>Vue.config.productionTip = false;</script>
   <style>[v-cloak] {display: none}</style>
 
-  <link rel="stylesheet" href="https://cdn.materialdesignicons.com/5.8.55/css/materialdesignicons.min.css" integrity="sha384-mXn03l3egUmSn2pZYz33om5XpEK6GclFj/DZp48zhus7gXuJlYs806Zpmhgy9MKb" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css" integrity="sha384-/frq1SRXYH/bSyou/HUp/hib7RVN1TawQYja658FEOodR/FQBKVqT9Ol+Oz3Olq5" crossorigin="anonymous">
-  <script src="https://unpkg.com/buefy@0.9.20/dist/buefy.min.js" integrity="sha384-J9o3RORmJhOZllvo14aPtzAeqyZjQ2TXL/ufXY1QYXc2RMuH72o0je0H+X6XBRi/" crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="https://unpkg.com/buefy@0.9.20/dist/buefy.min.css" integrity="sha384-QIdDkCURVg1BoIxyipzY5/NWEYfyx1pn30/Hmrbs12sHMf5XCrE2eWfQ2yafeoBy" crossorigin="anonymous">
-  <script src="https://unpkg.com/moment@2.29.1/min/moment.min.js" integrity="sha384-Uz1UHyakAAz121kPY0Nx6ZGzYeUTy9zAtcpdwVmFCEwiTGPA2K6zSGgkKJEQfMhK" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/zero-md@2.4.0/dist/zero-md.min.js" type="module" integrity="sha384-U3eQ8m7c4g0jOX9H+jodGDD0wlmItWNywe2VWPxoGr3DGq89yqNhUqmPhjMMyPgJ" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@7.4.47/css/materialdesignicons.min.css" integrity="sha384-HphS8cQyN+eYiJ5PMbzShG6qZdRtvHPVLPkYb8JwMkmNgaIxrFVDhQe3jIbq3EZ2" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.2/css/all.css" integrity="sha384-PPIZEGYM1v8zp5Py7UjFb79S58UeqCL9pYVnVPURKEqvioPROaVAJKKLzvH2rDnI" crossorigin="anonymous">
+  <script src="https://unpkg.com/buefy@0.9.29/dist/buefy.min.js" integrity="sha384-6JhI3PsQBPiHaSOuaAjOyxxs0DelGcjnJAOFmbomg9NuUpqufLqfuv41jHOf2z0G" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://unpkg.com/buefy@0.9.29/dist/buefy.min.css" integrity="sha384-XU9oGhqh0epfmMUKzxIpDEO0mhmJoURmiyQzP7RamvMFEcJESnKUDObvN8LDoMkc" crossorigin="anonymous">
+  <script src="https://unpkg.com/moment@2.30.1/min/moment.min.js" integrity="sha384-jzJ+sNWbKe71gDLLfQKgdtslQjhK70oKLFN+wmwxyg6mQN7Vem+wzce4pryF0HP/" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/zero-md@2.5.4/dist/zero-md.min.js" type="module" integrity="sha384-HYAxqGDSUbWswWhOZPO5wPwUgrEhMdsZMRI4+ZqSMKYYQ1KRWeh7pM28P/8Hiwqp" crossorigin="anonymous"></script>
 </head>
 
 <body >


### PR DESCRIPTION
When clicking on the markdown preview while searching for the respective md file, the path is faulty.
This can be fixed easily by applying the same replacer as in `searchByPrefix` to get the `pathPrefixDir`.

I also updated all the scripts and stylesheets while I was at it