### PR TITLE
feat: select files and download the selection (mobile card view handled)

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,34 @@
             #app .modified-column {
                 display: none !important;
             }
+
+            /* Selection checkbox: keep it in the card corner instead of a full-width empty band */
+            #app .b-table .table-wrapper.has-mobile-cards tbody tr {
+                position: relative;
+            }
+            #app .b-table .table-wrapper.has-mobile-cards td.checkbox-cell {
+                position: absolute;
+                top: 0.5rem;
+                right: 0.5rem;
+                width: auto;
+                padding: 0;
+                border: 0;
+            }
+            #app .b-table .table-wrapper.has-mobile-cards td.checkbox-cell::before {
+                display: none !important;
+            }
+
+            /* "Select all" header: show a label in card view instead of an empty card */
+            #app .b-table .table-wrapper.has-mobile-cards thead tr .checkbox-cell {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: 0.5rem 0.75rem;
+            }
+            #app .b-table .table-wrapper.has-mobile-cards thead tr .checkbox-cell::before {
+                content: "Select all";
+                font-weight: 600;
+            }
         }
     </style>
 </head>
@@ -293,6 +321,16 @@
                                 style=" height: fit-content; margin-left: 0.7rem;"
                         ></b-button>
 
+                        <!-- Download Selected Button -->
+                        <b-button
+                                v-if="checkedRows.length > 0"
+                                type="is-primary" rounded :loading="downloadAllFilesProgress !== null"
+                                icon-pack="fas"
+                                icon-left="download"
+                                @click="downloadSelectedFiles"
+                                style=" height: fit-content; margin-left: 0.7rem;"
+                        >{{ checkedRows.length }}</b-button>
+
                         <!-- Paginating Buttons -->
                         <div style="margin-left: 1.0rem;">
                             <div v-show="nextContinuationToken || previousContinuationTokens.length > 0"
@@ -336,6 +374,11 @@
                     :default-sort="config.defaultOrder.split('-')[0]"
                     :default-sort-direction="config.defaultOrder.split('-')[1]"
                     :mobile-cards="true"
+                    checkable
+                    checkbox-position="left"
+                    :checked-rows="checkedRows"
+                    :is-row-checkable="(row) => row.type === 'content'"
+                    @check="(rows) => checkedRows = rows.filter(row => row.type === 'content')"
             >
                 <b-table-column
                         v-slot="props"
@@ -699,6 +742,8 @@
                     downloadAllFilesCount: null,
                     downloadAllFilesReceivedCount: null,
                     downloadAllFilesProgress: null,
+
+                    checkedRows: [],
                 }
             },
             computed: {
@@ -729,6 +774,10 @@
                     this.searchPrefix = this.pathPrefix.replace(/^.*\//, '')
                     window.location.hash = this.pathPrefix
                     this.refresh()
+                },
+                pathContentTableData() {
+                    // reset selection whenever the listing changes (navigation, pagination, search)
+                    this.checkedRows = []
                 }
             },
             methods: {
@@ -762,14 +811,12 @@
                         this.refresh()
                     }
                 },
-                async downloadAllFiles() {
+                // Download the given file urls as a single zip archive (shared by
+                // "download all" and "download selected").
+                async downloadFilesAsZip(urls, archiveName) {
+                    if (!urls || urls.length === 0) return;
 
-
-                    const archiveFiles = this.pathContentTableData
-                        .filter(item => item.type === 'content')
-                        .map(item => item.url);
-
-                    this.downloadAllFilesCount = archiveFiles.length;
+                    this.downloadAllFilesCount = urls.length;
                     this.downloadAllFilesReceivedCount = 0;
                     this.downloadAllFilesProgress = 0;
 
@@ -777,16 +824,14 @@
                     let totalReceivedLength = 0;
                     let unknownTotal = false; // true if any file lacks Content-Length
 
-                    const archiveName = this.pathPrefix.split('/')
-                        .filter(part => part.trim()).pop();
-                    console.debug(`create archive for ${archiveName}...`)
+                    console.debug(`create archive ${archiveName}...`)
                     const archiveData = []
                     const archive = new fflate.Zip((err, data, final) => {
                         if (err) throw err;
                         archiveData.push(data);
                     });
 
-                    await Promise.all(archiveFiles.map(async (url) => {
+                    await Promise.all(urls.map(async (url) => {
                         const fileName = url.split('/')
                             .filter(part => part.trim()).pop();
                         console.debug(`downloading ${fileName}...`);
@@ -833,6 +878,23 @@
                     this.downloadAllFilesCount = null;
                     this.downloadAllFilesReceivedCount = null;
                     this.downloadAllFilesProgress = null;
+                },
+                async downloadAllFiles() {
+                    const urls = this.pathContentTableData
+                        .filter(item => item.type === 'content')
+                        .map(item => item.url);
+                    const archiveName = this.pathPrefix.split('/')
+                        .filter(part => part.trim()).pop();
+                    await this.downloadFilesAsZip(urls, archiveName);
+                },
+                async downloadSelectedFiles() {
+                    const urls = this.checkedRows
+                        .filter(row => row.type === 'content')
+                        .map(row => row.url);
+                    const archiveName = this.pathPrefix.split('/')
+                        .filter(part => part.trim()).pop();
+                    await this.downloadFilesAsZip(urls, archiveName);
+                    this.checkedRows = [];
                 },
                 async refresh() {
                     let listBucketResult


### PR DESCRIPTION
Resubmitting the "select files and download selection" feature, this time with the mobile card view handled so it doesn't break the layout.

**Feature**
- Adds a checkbox column so individual files can be selected (folders are not checkable).
- Adds a "Download selected (N)" button that zips and downloads only the checked files.
- Refactors `downloadAllFiles` into a shared `downloadFilesAsZip(urls, archiveName)` helper, reused by both "download all" and "download selected" (no new dependency — reuses fflate).

**Mobile card view (the regression from the previous PR, now fixed)**
All changes are inside the existing `@media (max-width: 768px)` block:
- The row checkbox is absolutely positioned in the top-right corner of each card instead of rendering as a full-width empty band above the file.
- The "select all" header checkbox (which Buefy keeps visible as a full-width block in card view) gets a "Select all" label so it reads as a real control instead of an empty card.

No changes to the desktop view. 